### PR TITLE
Add kubernetes implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform.*
 *tfstate*
 **/.terraform/*
 .DS_Store
+kubernetes/helm-config.yaml

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,39 @@
+# JupyterHub on Kubernetes
+
+This is our deployment of the official [helm chart](https://github.com/kubernetes/helm/blob/master/docs/charts.md) for JupyterHub. See the [docs](https://zero-to-jupyterhub.readthedocs.io/en/latest/) for more info.
+
+## Usage
+
+First off you need [helm](https://github.com/kubernetes/helm) if you don't have it already.
+
+The config file has been cleaned so that it can be pushed to GitHub. Therefore the first thing you need to do is make a copy of the config and populate some of the values.
+
+```shell
+cp example-helm-config.yaml helm-config.yaml
+```
+
+Generate some tokens to use a secrets.
+
+```shell
+openssl rand -hex 32
+openssl rand -hex 32
+```
+
+Replace `COOKIE_SECRET` and `PROXY_SECRET` with the generated strings.
+
+Create a new [GitHub oauth application](https://github.com/settings/applications/new) and replace the `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` with the provided tokens.
+
+Now you can go ahead and run helm.
+
+```shell
+# Install
+helm install jupyterhub/jupyterhub --version=v0.4 --name=jupyterhub.informaticslab.co.uk --namespace=jupyter -f kubernetes/helm-config.yaml
+
+# Apply changes
+kubectl --namespace=jupyter scale deployment hub-deployment --replicas=0
+helm upgrade jupyterhub.informaticslab.co.uk jupyterhub/jupyterhub --version=v0.4 -f kubernetes/helm-config.yaml
+kubectl --namespace=jupyter scale deployment hub-deployment --replicas=1
+
+# Delete
+helm delete jupyterhub.informaticslab.co.uk --purge
+```

--- a/kubernetes/example-helm-config.yaml
+++ b/kubernetes/example-helm-config.yaml
@@ -1,0 +1,39 @@
+hub:
+  cookieSecret: "COOKIE_SECRET"
+  extraConfig: |
+    c.JupyterHub.logo_file = 'https://images.informaticslab.co.uk/misc/822630db09e112db715ea5b18d03fa7b.png'
+
+proxy:
+  secretToken: "PROXY_SECRET"
+  service:
+    type: ClusterIP
+
+prePuller:
+  enabled: false
+
+ingress:
+  enabled: true
+  host: jupyterhub.informaticslab.co.uk
+  https:
+    enabled: true
+    type: "kube-lego"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+
+auth:
+  type: github
+  github:
+    clientId: "GITHUB_CLIENT_ID"
+    clientSecret: "GITHUB_CLIENT_SECRET"
+    callbackUrl: "https://jupyterhub.informaticslab.co.uk/hub/oauth_callback"
+
+singleuser:
+  image:
+    name: informaticslab/singleuser-notebook
+    tag: latest
+
+admin:
+  access: true
+  users:
+    - jacobtomlinson
+    - niallrobinson


### PR DESCRIPTION
This set of kubernetes config files creates a JupyterHub implementation on a Kubernetes cluster. _This is a separate implementation to the terraform one._

A new namespace will be created with a JupyterHub service and a proxy for access. A role will be created which will allow JupyterHub to request new user notebook containers. Kubernetes will automatically provision a 10GB EBS volume to use as the notebook home directory. This volume will follow the user notebook container around the cluster, however that does slow down the start of a container. 